### PR TITLE
Use strong security headers during web development

### DIFF
--- a/chapter-13-browser-based-apps/browser-based-application/webpack/webpack.dev.ts
+++ b/chapter-13-browser-based-apps/browser-based-application/webpack/webpack.dev.ts
@@ -20,15 +20,19 @@ import {Configuration as WebpackDevServerConfiguration} from 'webpack-dev-server
 import {merge} from 'webpack-merge';
 import baseConfig from './webpack.common.js';
 
-/*
- * A pure SPA experience is used for web development, using a lightweight static server
- */
-const dirname = process.cwd();
-let devConfig: webpack.Configuration = {
-    mode: 'development',
-};
+let policy = "default-src 'none';";
+policy += " script-src 'self';";
+policy += " connect-src 'self' https://api.webapp.example;";
+policy += " child-src 'self';";
+policy += " img-src 'self';";
+policy += " style-src 'self' https://cdn.jsdelivr.net;";
+policy += " object-src 'none';";
+policy += " frame-ancestors 'none';";
+policy += " base-uri 'self';";
+policy += " form-action 'self'";
 
-let devServerConfig: WebpackDevServerConfiguration = {
+const dirname = process.cwd();
+let devServer: WebpackDevServerConfiguration = {
     server: {
         type: 'https',
         options: {
@@ -47,7 +51,43 @@ let devServerConfig: WebpackDevServerConfiguration = {
     allowedHosts: [
         'www.webapp.example'
     ],
+    /*
+    * During development the app uses a lightweight web host and sets strong security headers
+    * Equivalent headers should also be set when the SPA is deployed to its production web host
+    */
+
+    headers: [
+        {
+            key: 'content-security-policy',
+            value: policy,
+        },
+        {
+            key: 'strict-transport-security',
+            value: 'max-age=31536000; includeSubdomains; preload',
+        },
+        {
+            key: 'x-frame-options',
+            value: 'DENY',
+        },
+        {
+            key: 'x-xss-protection',
+            value: '1; mode=block',
+        },
+        {
+            key: 'x-content-type-options',
+            value: 'nosniff',
+        },
+        {
+            key: 'referrer-policy',
+            value: 'same-origin',
+        },
+    ],
 };
 
-devConfig.devServer = devServerConfig;
+let devConfig: webpack.Configuration = {
+    mode: 'development',
+    devtool: 'source-map',
+    devServer,
+};
+
 export default merge(baseConfig, devConfig);

--- a/chapter-13-browser-based-apps/browser-based-application/webpack/webpack.prod.ts
+++ b/chapter-13-browser-based-apps/browser-based-application/webpack/webpack.prod.ts
@@ -18,22 +18,6 @@ import webpack from 'webpack';
 import {merge} from 'webpack-merge';
 import baseConfig from './webpack.common.js';
 
-/*
- * When deploying to a real web host, you should include recommended web security headers and a content security policy.
- * This should only allow access to trusted hosts, like the backend for frontend.
- * https://owasp.org/www-project-secure-headers/
- */
-let policy = "default-src 'none';";
-policy += " script-src 'self';";
-policy += " connect-src 'self' https://api.webapp.example;";
-policy += " child-src 'self';";
-policy += " img-src 'self';";
-policy += " style-src 'self' https://cdn.jsdelivr.net;";
-policy += " object-src 'none';";
-policy += " frame-ancestors 'none';";
-policy += " base-uri 'self';";
-policy += " form-action 'self'";
-
 const prodConfig: webpack.Configuration = {
   mode: 'production',
 };


### PR DESCRIPTION
Previously I had thought that webpack dev server required insecure options like unsafe-eval, but it turns out that it does not, as long as you use source maps. Therefore our example can use secure headers for development, like those in [various online articles](https://aws.amazon.com/blogs/networking-and-content-delivery/adding-http-security-headers-using-lambdaedge-and-amazon-cloudfront/).