### PR TITLE
Memory issue on Linux

### DIFF
--- a/resources/base/cluster.yaml
+++ b/resources/base/cluster.yaml
@@ -3,4 +3,10 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
+  extraMounts:
+  - hostPath: containerd.service
+    containerPath: /etc/systemd/system/containerd.service
 - role: worker
+  extraMounts:
+  - hostPath: containerd.service
+    containerPath: /etc/systemd/

--- a/resources/base/containerd.service
+++ b/resources/base/containerd.service
@@ -1,0 +1,25 @@
+################################################################################################################################
+# Overrides the default KIND file that uses LimitNOFILE=infinity to avoid high memory issues on experimental Linux distributions
+################################################################################################################################
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+StartLimitIntervalSec=0
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=1
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
KIND sets [aggressive memory limits](https://github.com/containerd/containerd/pull/8924) that can cause issues with some containers.\
This PR is a safe change to ensure no ill effects for developers running experimental Linux distros like Ubuntu 24.10.