### PR TITLE
Update to opa v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # General
 .settings/
 .DS_Store
+.vscode/
 *democluster*
 *.jar
 *.tar.gz

--- a/chapter-05-secure-api-development/deployment/deployment-policy.yaml
+++ b/chapter-05-secure-api-development/deployment/deployment-policy.yaml
@@ -16,43 +16,43 @@ spec:
     spec:
       serviceAccountName: zerotrustapi
       containers:
-      - name: zerotrustapi
-        image: zerotrustapi:1.0.0
-        env:
-          - name: NODE_ENV
-            value: 'production'
-          - name: PORT
-            value: '8000'
-          - name: JWKS_URI
-            value: 'http://curity-idsvr-runtime-svc.authorizationserver:8443/oauth/v2/oauth-anonymous/jwks'
-          - name: REQUIRED_JWT_ALGORITHM
-            value: 'ES256'
-          - name: 'REQUIRED_ISSUER'
-            value: 'https://login.democluster.example/oauth/v2/oauth-anonymous'
-          - name: 'REQUIRED_AUDIENCE'
-            value: 'api.example.com'
-          - name: 'REQUIRED_SCOPE'
-            value: 'retail/orders'
-          - name: 'AUTHORIZATION_STRATEGY'
-            value: 'policy'
-          - name: 'POLICY_ENDPOINT'
-            value: 'http://127.0.0.1:8181/v1/data/orders/allow'
+        - name: zerotrustapi
+          image: zerotrustapi:1.0.0
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: "8000"
+            - name: JWKS_URI
+              value: "http://curity-idsvr-runtime-svc.authorizationserver:8443/oauth/v2/oauth-anonymous/jwks"
+            - name: REQUIRED_JWT_ALGORITHM
+              value: "ES256"
+            - name: "REQUIRED_ISSUER"
+              value: "https://login.democluster.example/oauth/v2/oauth-anonymous"
+            - name: "REQUIRED_AUDIENCE"
+              value: "api.example.com"
+            - name: "REQUIRED_SCOPE"
+              value: "retail/orders"
+            - name: "AUTHORIZATION_STRATEGY"
+              value: "policy"
+            - name: "POLICY_ENDPOINT"
+              value: "http://127.0.0.1:8181/v1/data/orders/allow"
       initContainers:
-      - name: policyengine
-        image: openpolicyagent/opa:0.69.0
-        restartPolicy: Always
-        args:
-          - "run"
-          - "--ignore=.*" # Ignore kubernetes specific files
-          - "--server"
-          - "--addr"
-          - "127.0.0.1:8181" # Listen on local interface
-          - "--set"
-          - "decision_logs.console=true" # Enable decision logs
-          - "--set" 
-          - "services.policyRetrievalPoint.url=http://policy-retrieval-point-svc" # Base-URL of server hosting the policy bundle
-          - "--set"
-          - "bundles.policyRetrievalPoint.resource=orders_bundle.tar.gz" # Path of the orders policy bundle on the server
-          - "--set"
-          - "bundles.policyRetrievalPoint.persist=false" # Keep policy in memory
-          - "--v1-compatible"
+        - name: policyengine
+          image: openpolicyagent/opa:1.3.0
+          restartPolicy: Always
+          args:
+            - "run"
+            - "--ignore=.*" # Ignore kubernetes specific files
+            - "--server"
+            - "--addr"
+            - "127.0.0.1:8181" # Listen on local interface
+            - "--set"
+            - "decision_logs.console=true" # Enable decision logs
+            - "--set"
+            - "services.policyRetrievalPoint.url=http://policy-retrieval-point-svc" # Base-URL of server hosting the policy bundle
+            - "--set"
+            - "bundles.policyRetrievalPoint.resource=orders_bundle.tar.gz" # Path of the orders policy bundle on the server
+            - "--set"
+            - "bundles.policyRetrievalPoint.persist=false" # Keep policy in memory
+            - "--v1-compatible"

--- a/chapter-09-entitlements/policy-retrieval-point/policy/logging.rego
+++ b/chapter-09-entitlements/policy-retrieval-point/policy/logging.rego
@@ -1,7 +1,5 @@
 package system.log
 
-import rego.v1
-
 #
 # Demonstrate adding token data to decision logs
 #

--- a/chapter-09-entitlements/policy-retrieval-point/policy/orders.rego
+++ b/chapter-09-entitlements/policy-retrieval-point/policy/orders.rego
@@ -16,8 +16,6 @@
 
 package orders
 
-import rego.v1
-
 #
 # Import volatile business permissions that map to the role in the access token
 # (business permissions are not part of the access token)


### PR DESCRIPTION
Changes OPA docker image to current latest (1.3.0) tag.
Removes import statements from policies (not needed anymore now that OPA/Rego is version 1.x).

+ Ignore .vscode/ in git.
+ code formatting.

Fixes #22 