### PR TITLE
Kong gateway fix

### DIFF
--- a/resources/apigateway/Dockerfile
+++ b/resources/apigateway/Dockerfile
@@ -1,11 +1,11 @@
-FROM kong/kong:3.8-ubuntu
+FROM kong/kong:3.9-ubuntu
 
 #
 # Install libraries our example plugins depend upon
 #
 USER root
 RUN apt-get update
-RUN apt-get install -y git unzip
+RUN apt-get install -y git unzip wget
 
 RUN git config --global url."https://".insteadOf git:// && \
     git config --global advice.detachedHead false && \

--- a/resources/apigateway/deploy-api-gateway.sh
+++ b/resources/apigateway/deploy-api-gateway.sh
@@ -18,6 +18,15 @@ kubectl create namespace kong
 kubectl label namespace kong name=kong
 
 #
+# Pull the latest Docker image to ensure no issues with old versions and LUA install dependencies
+#
+docker pull kong/kong:3.9-ubuntu
+if [ $? -ne 0 ]; then
+  echo 'Problem pulling the custom Kong docker image'
+  exit 1
+fi
+
+#
 # Build the custom docker image with plugin dependencies
 #
 docker build --no-cache -t custom-kong:1.0.0 .


### PR DESCRIPTION
Fixed a confusing luarocks install problem that happened as new versions got released based on a tag like this.\
Based on a similar recent change to another repo.

```dockerfile
FROM kong/kong:3.9-ubuntu
```